### PR TITLE
In-correct count of the number of edges in the detail view when a related vertex is not visible to the user

### DIFF
--- a/web/web-base/src/main/java/io/lumify/web/routes/vertex/VertexEdges.java
+++ b/web/web-base/src/main/java/io/lumify/web/routes/vertex/VertexEdges.java
@@ -75,7 +75,7 @@ public class VertexEdges extends BaseRequestHandler {
             result.getRelationships().add(clientApiEdge);
             referencesAdded++;
         }
-        result.setTotalReferences(totalReferences);
+        result.setTotalReferences(referencesAdded);
 
         respondWithClientApiObject(response, result);
     }


### PR DESCRIPTION
Create vertices A, B and C - such that edges are A-> B, B -> C and A->C.
Set the visibility of vertex B such that its not visible to user.
When you see the detail view for vertex A, the count of edges show the total number of edges i.e. 2 rather than 1 that the user has access to.
