### PR TITLE
Dockerfile bug fixes

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -42,9 +42,6 @@ EXPOSE 2181 2888 3888
 # Install Hadoop
 ADD scripts/install-hadoop.sh /opt/lumify/scripts/install-hadoop.sh
 ADD hadoop/core-site.xml.template /opt/hadoop-2.3.0/etc/hadoop/core-site.xml.template
-ADD hadoop/hdfs-site.xml /opt/hadoop-2.3.0/etc/hadoop/hdfs-site.xml
-ADD hadoop/mapred-site.xml /opt/hadoop-2.3.0/etc/hadoop/mapred-site.xml
-ADD hadoop/yarn-site.xml /opt/hadoop-2.3.0/etc/hadoop/yarn-site.xml
 COPY hadoop/hadoop-native-64bit.tar.gz /opt/hadoop-2.3.0/hadoop-native-64bit.tar.gz
 ENV HADOOP_PREFIX /opt/hadoop
 ENV HADOOP_COMMON_HOME /opt/hadoop
@@ -55,6 +52,9 @@ ENV HADOOP_CONF_DIR /opt/hadoop/etc/hadoop
 ENV YARN_CONF_DIR /opt/hadoop/etc/hadoop
 ENV PATH $PATH:/opt/hadoop/bin
 RUN /bin/bash /opt/lumify/scripts/install-hadoop.sh
+ADD hadoop/hdfs-site.xml /opt/hadoop-2.3.0/etc/hadoop/hdfs-site.xml
+ADD hadoop/mapred-site.xml /opt/hadoop-2.3.0/etc/hadoop/mapred-site.xml
+ADD hadoop/yarn-site.xml /opt/hadoop-2.3.0/etc/hadoop/yarn-site.xml
 VOLUME ["/var/lib/hadoop-hdfs", "/var/local/hadoop"]
 EXPOSE 8020 8032 8088 9000 50010 50020 50030 50060 50070 50075 50090
 

--- a/docker/dev/scripts/install-jetty.sh
+++ b/docker/dev/scripts/install-jetty.sh
@@ -3,7 +3,7 @@
 jetty_version=9.2.7.v20150116
 jetty_tgz=jetty-distribution-${jetty_version}.tar.gz
 
-wget -O /opt/${jetty_tgz} http://download.eclipse.org/jetty/${jetty_version}/dist/${jetty_tgz}
+wget -O /opt/${jetty_tgz} http://archive.eclipse.org/jetty/${jetty_version}/dist/${jetty_tgz}
 tar -xzf /opt/${jetty_tgz} -C /opt
 rm /opt/${jetty_tgz}
 ln -s /opt/jetty-distribution-${jetty_version} /opt/jetty


### PR DESCRIPTION
Changed the hadoop/yarn section of the Dockerfile to copy config files after exploding the hadoop tar-ball, so the config files are not blown away when exploding the tar-ball. 