### PR TITLE
Change the trace.token.property.password to match the root password

### DIFF
--- a/docker/dev/scripts/install-accumulo.sh
+++ b/docker/dev/scripts/install-accumulo.sh
@@ -18,3 +18,4 @@ sed -i -e "s|localhost|0.0.0.0|" /opt/accumulo/conf/slaves
 sed -i -e "s|localhost|0.0.0.0|" /opt/accumulo/conf/tracers
 sed -i -e "s|localhost|0.0.0.0|" /opt/accumulo/conf/gc
 sed -i -e "s|localhost|0.0.0.0|" /opt/accumulo/conf/monitor
+sed -i -e "s|<value>secret</value>|<value>password</value>|" /opt/accumulo/conf/accumulo-site.xml


### PR DESCRIPTION
The trace password is set separately from the root password.  This change set them to be the same and avoids the ThriftSecurityException(user:root, code:BAD_CREDENTIALS) errors.