### PR TITLE
Mock the WorkQueueRepository for Graph Property Worker Tests

### DIFF
--- a/graph-property-worker/plugins/known-entity-extractor/src/test/java/io/lumify/knownEntity/KnownEntityExtractorGraphPropertyWorkerTest.java
+++ b/graph-property-worker/plugins/known-entity-extractor/src/test/java/io/lumify/knownEntity/KnownEntityExtractorGraphPropertyWorkerTest.java
@@ -9,6 +9,7 @@ import io.lumify.core.model.audit.AuditRepository;
 import io.lumify.core.model.ontology.OntologyRepository;
 import io.lumify.core.model.properties.LumifyProperties;
 import io.lumify.core.model.termMention.TermMentionRepository;
+import io.lumify.core.model.workQueue.WorkQueueRepository;
 import io.lumify.core.security.DirectVisibilityTranslator;
 import io.lumify.core.security.VisibilityTranslator;
 import io.lumify.core.user.User;
@@ -19,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.MockPolicy;
 import org.securegraph.*;
 import org.securegraph.inmemory.InMemoryAuthorizations;
 import org.securegraph.inmemory.InMemoryGraph;
@@ -48,6 +50,9 @@ public class KnownEntityExtractorGraphPropertyWorkerTest {
     @Mock
     private OntologyRepository ontologyRepository;
 
+    @Mock
+    private WorkQueueRepository workQueueRepository;
+
     String dictionaryPath;
     private InMemoryAuthorizations authorizations;
     private InMemoryAuthorizations termMentionAuthorizations;
@@ -75,6 +80,7 @@ public class KnownEntityExtractorGraphPropertyWorkerTest {
         extractor.setVisibilityTranslator(visibilityTranslator);
         extractor.setConfiguration(configuration);
         extractor.setOntologyRepository(ontologyRepository);
+        extractor.setWorkQueueRepository(workQueueRepository);
 
         config.put(KnownEntityExtractorGraphPropertyWorker.PATH_PREFIX_CONFIG, "file://" + dictionaryPath);
         FileSystem hdfsFileSystem = FileSystem.get(new Configuration());

--- a/graph-property-worker/plugins/known-entity-extractor/src/test/java/io/lumify/knownEntity/KnownEntityExtractorGraphPropertyWorkerTest.java
+++ b/graph-property-worker/plugins/known-entity-extractor/src/test/java/io/lumify/knownEntity/KnownEntityExtractorGraphPropertyWorkerTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.MockPolicy;
 import org.securegraph.*;
 import org.securegraph.inmemory.InMemoryAuthorizations;
 import org.securegraph.inmemory.InMemoryGraph;

--- a/graph-property-worker/plugins/opennlp-dictionary-extractor/src/test/java/io/lumify/opennlpDictionary/OpenNLPDictionaryExtractorGraphPropertyWorkerTest.java
+++ b/graph-property-worker/plugins/opennlp-dictionary-extractor/src/test/java/io/lumify/opennlpDictionary/OpenNLPDictionaryExtractorGraphPropertyWorkerTest.java
@@ -10,6 +10,7 @@ import io.lumify.core.model.properties.LumifyProperties;
 import io.lumify.core.model.termMention.TermMentionRepository;
 import io.lumify.core.model.user.AuthorizationRepository;
 import io.lumify.core.model.user.InMemoryAuthorizationRepository;
+import io.lumify.core.model.workQueue.WorkQueueRepository;
 import io.lumify.core.security.DirectVisibilityTranslator;
 import io.lumify.core.security.VisibilityTranslator;
 import io.lumify.core.user.User;
@@ -61,6 +62,9 @@ public class OpenNLPDictionaryExtractorGraphPropertyWorkerTest {
     @Mock
     private OntologyRepository ontologyRepository;
 
+    @Mock
+    private WorkQueueRepository workQueueRepository;
+
     private InMemoryGraph graph;
     private VisibilityTranslator visibilityTranslator = new DirectVisibilityTranslator();
     private TermMentionRepository termMentionRepository;
@@ -93,6 +97,7 @@ public class OpenNLPDictionaryExtractorGraphPropertyWorkerTest {
         extractor.setVisibilityTranslator(visibilityTranslator);
         extractor.setGraph(graph);
         extractor.setOntologyRepository(ontologyRepository);
+        extractor.setWorkQueueRepository(workQueueRepository);
 
         AuthorizationRepository authorizationRepository = new InMemoryAuthorizationRepository();
         termMentionRepository = new TermMentionRepository(graph, authorizationRepository);

--- a/graph-property-worker/plugins/opennlp-me-extractor/src/test/java/io/lumify/opennlpme/OpenNLPMaximumEntropyExtractorGraphPropertyWorkerTest.java
+++ b/graph-property-worker/plugins/opennlp-me-extractor/src/test/java/io/lumify/opennlpme/OpenNLPMaximumEntropyExtractorGraphPropertyWorkerTest.java
@@ -8,6 +8,7 @@ import io.lumify.core.ingest.graphProperty.TermMentionFilter;
 import io.lumify.core.model.ontology.OntologyRepository;
 import io.lumify.core.model.properties.LumifyProperties;
 import io.lumify.core.model.termMention.TermMentionRepository;
+import io.lumify.core.model.workQueue.WorkQueueRepository;
 import io.lumify.core.security.DirectVisibilityTranslator;
 import io.lumify.core.security.VisibilityTranslator;
 import io.lumify.core.user.User;
@@ -52,6 +53,9 @@ public class OpenNLPMaximumEntropyExtractorGraphPropertyWorkerTest {
     @Mock
     private User user;
 
+    @Mock
+    private WorkQueueRepository workQueueRepository;
+
     private String text = "This is a sentenc®, written by Bob Robértson, who curréntly makes 2 million "
             + "a year. If by 1:30, you don't know what you are doing, you should go watch CNN and see "
             + "what the latest is on the Benghazi nonsense. I'm 47% sure that this test will pass, but will it?";
@@ -76,6 +80,7 @@ public class OpenNLPMaximumEntropyExtractorGraphPropertyWorkerTest {
         extractor.setConfiguration(configuration);
         extractor.setGraph(graph);
         extractor.setOntologyRepository(ontologyRepository);
+        extractor.setWorkQueueRepository(workQueueRepository);
 
         Map<String, String> conf = new HashMap<>();
         conf.put("ontology.intent.concept.location", "http://lumify.io/test#location");

--- a/graph-property-worker/plugins/phone-number-extractor/src/test/java/io/lumify/phoneNumber/PhoneNumberGraphPropertyWorkerTest.java
+++ b/graph-property-worker/plugins/phone-number-extractor/src/test/java/io/lumify/phoneNumber/PhoneNumberGraphPropertyWorkerTest.java
@@ -9,6 +9,7 @@ import io.lumify.core.ingest.graphProperty.TermMentionFilter;
 import io.lumify.core.model.ontology.OntologyRepository;
 import io.lumify.core.model.properties.LumifyProperties;
 import io.lumify.core.model.termMention.TermMentionRepository;
+import io.lumify.core.model.workQueue.WorkQueueRepository;
 import io.lumify.core.security.DirectVisibilityTranslator;
 import io.lumify.core.security.VisibilityTranslator;
 import io.lumify.core.user.User;
@@ -48,6 +49,9 @@ public class PhoneNumberGraphPropertyWorkerTest {
     @Mock
     private OntologyRepository ontologyRepository;
 
+    @Mock
+    private WorkQueueRepository workQueueRepository;
+
     private PhoneNumberGraphPropertyWorker extractor;
     private InMemoryAuthorizations authorizations;
     private InMemoryGraph graph;
@@ -72,6 +76,7 @@ public class PhoneNumberGraphPropertyWorkerTest {
         extractor.setConfiguration(configuration);
         extractor.setVisibilityTranslator(visibilityTranslator);
         extractor.setOntologyRepository(ontologyRepository);
+        extractor.setWorkQueueRepository(workQueueRepository);
 
         FileSystem hdfsFileSystem = null;
         authorizations = new InMemoryAuthorizations(TermMentionRepository.VISIBILITY_STRING);


### PR DESCRIPTION
Mock the WorkQueueRepository for Graph Property Worker Tests to prevent the null pointer exceptions that were occurring in the unit test.