### PR TITLE
Updated description of configuration file location

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,8 +20,8 @@ By default Lumify will use `io.lumify.core.config.FileConfigurationLoader` to lo
 * `${user.home}/.lumify`
 * Directory specified by the environment variable `LUMIFY_DIR`
 
-Each of these directories will be searched in order and all files with a `.properties` extension will be
-read in alphabetic order. This allows you to override properties in various places.
+The config directory of each of these directories will be searched in order and all files with a `.properties` extension 
+will be read in alphabetic order. This allows you to override properties in various places.
 
 ## Docker
 


### PR DESCRIPTION
The locations specified didn't mention that `io.lumify.core.config.FileConfigurationLoader` will actually look for a `config` directory in each of the locations. It took me a few minutes of looking at source to figure out I couldn't do `c:/opt/lumify/lumify.properties` but needed to do `c:/opt/lumify/config/lumify.properties`.
